### PR TITLE
Add support for structured logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,13 @@ Run [`cargo-release`][cr] to publish a release.
 - Add `JournalLog::with_extra_fields` and `init_with_extra_fields` to add custom fields to every log entry (see [GH-3]).
 - Add new `journal_send` to send an individual log record directly to the systemd journal.
 - Add new `connected_to_journal` function to check for a direct connection to the systemd log in order to automatically upgrade to journal logging in systemd services (see [GH-5]).
+- Add record key values as custom journal fields (see [GH-1]).
 
 ### Changed
 - Do not silently ignore journal errors; instead panic if the logger fails to send a message to the systemd journal.
 - Use `CODE_MODULE` field for the Rust module path, for compatibility with the `slog-journal` and `systemd` crates.
 
+[GH-1]: https://github.com/lunaryorn/systemd-journal-logger.rs/pull/1
 [GH-3]: https://github.com/lunaryorn/systemd-journal-logger.rs/pull/3
 [GH-5]: https://github.com/lunaryorn/systemd-journal-logger.rs/pull/5
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,9 @@ edition = "2018"
 
 [dependencies]
 # libsystemd isn't no_std compatible so we can conveniently enable log's std
-# feature unconditionally
-log = { version = "^0.4", features = ["std"] }
+# feature unconditionally.  We require std for the set_boxed_logger field in
+# init_with_extra_fields.
+log = { version = "^0.4", features = ["std", "kv_unstable"] }
 libsystemd = "^0.3"
 nix = "^0.21"
 libc = "^0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,12 +91,9 @@
 //! # Errors
 //!
 //! This crate currently does not implement any kind of error handling for journal messages.
-//!
 //! In particular it will **panic** when sending a record to journald fails, e.g. if journald is
-//! not running.
-//!
-//! Given that journald on systemd systems is pretty essential and very reliable there are currently
-//! no plans to change this behaviour.
+//! not running.  There are no plans to change this behaviour, give that journald is reliable in
+//! general.
 //!
 //! To implement an alternative error handling behaviour define a custom log implementation around
 //! [`journal_send`] which sends a single log record to the journal.


### PR DESCRIPTION
## TODO

- [x] Uppercase keys? systemd ignores lowercase keys.
- [x] Escape unsupported characters? If so, how?